### PR TITLE
Add IEEE33 test case

### DIFF
--- a/gym_anm/__init__.py
+++ b/gym_anm/__init__.py
@@ -4,8 +4,14 @@ from gymnasium.envs.registration import register
 
 from .agents import MPCAgentPerfect, MPCAgentConstant
 from .envs import ANMEnv
+from .envs.ieee33_env import IEEE33Env
 
 register(
     id="ANM6Easy-v0",
     entry_point="gym_anm.envs:ANM6Easy",
+)
+
+register(
+    id="IEEE33-v0",
+    entry_point="gym_anm.envs.ieee33_env:IEEE33Env",
 )

--- a/gym_anm/envs/__init__.py
+++ b/gym_anm/envs/__init__.py
@@ -3,3 +3,4 @@
 from .anm_env import ANMEnv
 from .anm6_env.anm6 import ANM6
 from .anm6_env.anm6_easy import ANM6Easy
+from .ieee33_env.ieee33 import IEEE33Env

--- a/gym_anm/envs/ieee33_env/__init__.py
+++ b/gym_anm/envs/ieee33_env/__init__.py
@@ -1,0 +1,3 @@
+"""IEEE 33-bus distribution test system."""
+
+from .ieee33 import IEEE33Env

--- a/gym_anm/envs/ieee33_env/case33bw.m
+++ b/gym_anm/envs/ieee33_env/case33bw.m
@@ -1,0 +1,125 @@
+function mpc = case33bw
+%CASE33BW  Power flow data for 33 bus distribution system from Baran & Wu
+%   Please see CASEFORMAT for details on the case file format.
+%
+%   Data from ...
+%       M. E. Baran and F. F. Wu, "Network reconfiguration in distribution
+%       systems for loss reduction and load balancing," in IEEE Transactions
+%       on Power Delivery, vol. 4, no. 2, pp. 1401-1407, Apr 1989.
+%       doi: 10.1109/61.25627
+%       URL: https://doi.org/10.1109/61.25627
+
+%% MATPOWER Case Format : Version 2
+mpc.version = '2';
+
+%%-----  Power Flow Data  -----%%
+%% system MVA base
+mpc.baseMVA = 10;
+
+%% bus data
+%	bus_i	type	Pd	Qd	Gs	Bs	area	Vm	Va	baseKV	zone	Vmax	Vmin
+mpc.bus = [ %% (Pd and Qd are specified in kW & kVAr here, converted to MW & MVAr below)
+	1	3	0	0	0	0	1	1	0	12.66	1	1	1;
+	2	1	100	60	0	0	1	1	0	12.66	1	1.1	0.9;
+	3	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	4	1	120	80	0	0	1	1	0	12.66	1	1.1	0.9;
+	5	1	60	30	0	0	1	1	0	12.66	1	1.1	0.9;
+	6	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	7	1	200	100	0	0	1	1	0	12.66	1	1.1	0.9;
+	8	1	200	100	0	0	1	1	0	12.66	1	1.1	0.9;
+	9	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	10	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	11	1	45	30	0	0	1	1	0	12.66	1	1.1	0.9;
+	12	1	60	35	0	0	1	1	0	12.66	1	1.1	0.9;
+	13	1	60	35	0	0	1	1	0	12.66	1	1.1	0.9;
+	14	1	120	80	0	0	1	1	0	12.66	1	1.1	0.9;
+	15	1	60	10	0	0	1	1	0	12.66	1	1.1	0.9;
+	16	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	17	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	18	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	19	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	20	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	21	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	22	1	90	40	0	0	1	1	0	12.66	1	1.1	0.9;
+	23	1	90	50	0	0	1	1	0	12.66	1	1.1	0.9;
+	24	1	420	200	0	0	1	1	0	12.66	1	1.1	0.9;
+	25	1	420	200	0	0	1	1	0	12.66	1	1.1	0.9;
+	26	1	60	25	0	0	1	1	0	12.66	1	1.1	0.9;
+	27	1	60	25	0	0	1	1	0	12.66	1	1.1	0.9;
+	28	1	60	20	0	0	1	1	0	12.66	1	1.1	0.9;
+	29	1	120	70	0	0	1	1	0	12.66	1	1.1	0.9;
+	30	1	200	600	0	0	1	1	0	12.66	1	1.1	0.9;
+	31	1	150	70	0	0	1	1	0	12.66	1	1.1	0.9;
+	32	1	210	100	0	0	1	1	0	12.66	1	1.1	0.9;
+	33	1	60	40	0	0	1	1	0	12.66	1	1.1	0.9;
+];
+
+%% generator data
+%	bus	Pg	Qg	Qmax	Qmin	Vg	mBase	status	Pmax	Pmin	Pc1	Pc2	Qc1min	Qc1max	Qc2min	Qc2max	ramp_agc	ramp_10	ramp_30	ramp_q	apf
+mpc.gen = [
+	1	0	0	10	-10	1	100	1	10	0	0	0	0	0	0	0	0	0	0	0	0;
+];
+
+%% branch data
+%	fbus	tbus	r	x	b	rateA	rateB	rateC	ratio	angle	status	angmin	angmax
+mpc.branch = [  %% (r and x specified in ohms here, converted to p.u. below)
+	1	2	0.0922	0.0470	0	0	0	0	0	0	1	-360	360;
+	2	3	0.4930	0.2511	0	0	0	0	0	0	1	-360	360;
+	3	4	0.3660	0.1864	0	0	0	0	0	0	1	-360	360;
+	4	5	0.3811	0.1941	0	0	0	0	0	0	1	-360	360;
+	5	6	0.8190	0.7070	0	0	0	0	0	0	1	-360	360;
+	6	7	0.1872	0.6188	0	0	0	0	0	0	1	-360	360;
+	7	8	0.7114	0.2351	0	0	0	0	0	0	1	-360	360;
+	8	9	1.0300	0.7400	0	0	0	0	0	0	1	-360	360;
+	9	10	1.0440	0.7400	0	0	0	0	0	0	1	-360	360;
+	10	11	0.1966	0.0650	0	0	0	0	0	0	1	-360	360;
+	11	12	0.3744	0.1238	0	0	0	0	0	0	1	-360	360;
+	12	13	1.4680	1.1550	0	0	0	0	0	0	1	-360	360;
+	13	14	0.5416	0.7129	0	0	0	0	0	0	1	-360	360;
+	14	15	0.5910	0.5260	0	0	0	0	0	0	1	-360	360;
+	15	16	0.7463	0.5450	0	0	0	0	0	0	1	-360	360;
+	16	17	1.2890	1.7210	0	0	0	0	0	0	1	-360	360;
+	17	18	0.7320	0.5740	0	0	0	0	0	0	1	-360	360;
+	2	19	0.1640	0.1565	0	0	0	0	0	0	1	-360	360;
+	19	20	1.5042	1.3554	0	0	0	0	0	0	1	-360	360;
+	20	21	0.4095	0.4784	0	0	0	0	0	0	1	-360	360;
+	21	22	0.7089	0.9373	0	0	0	0	0	0	1	-360	360;
+	3	23	0.4512	0.3083	0	0	0	0	0	0	1	-360	360;
+	23	24	0.8980	0.7091	0	0	0	0	0	0	1	-360	360;
+	24	25	0.8960	0.7011	0	0	0	0	0	0	1	-360	360;
+	6	26	0.2030	0.1034	0	0	0	0	0	0	1	-360	360;
+	26	27	0.2842	0.1447	0	0	0	0	0	0	1	-360	360;
+	27	28	1.0590	0.9337	0	0	0	0	0	0	1	-360	360;
+	28	29	0.8042	0.7006	0	0	0	0	0	0	1	-360	360;
+	29	30	0.5075	0.2585	0	0	0	0	0	0	1	-360	360;
+	30	31	0.9744	0.9630	0	0	0	0	0	0	1	-360	360;
+	31	32	0.3105	0.3619	0	0	0	0	0	0	1	-360	360;
+	32	33	0.3410	0.5302	0	0	0	0	0	0	1	-360	360;
+	21	8	2.0000	2.0000	0	0	0	0	0	0	0	-360	360;
+	9	15	2.0000	2.0000	0	0	0	0	0	0	0	-360	360;
+	12	22	2.0000	2.0000	0	0	0	0	0	0	0	-360	360;
+	18	33	0.5000	0.5000	0	0	0	0	0	0	0	-360	360;
+	25	29	0.5000	0.5000	0	0	0	0	0	0	0	-360	360;
+];
+
+%%-----  OPF Data  -----%%
+%% generator cost data
+%	1	startup	shutdown	n	x1	y1	...	xn	yn
+%	2	startup	shutdown	n	c(n-1)	...	c0
+mpc.gencost = [
+	2	0	0	3	0	20	0;
+];
+
+
+%% convert branch impedances from Ohms to p.u.
+[PQ, PV, REF, NONE, BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, ...
+    VA, BASE_KV, ZONE, VMAX, VMIN, LAM_P, LAM_Q, MU_VMAX, MU_VMIN] = idx_bus;
+[F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, RATE_B, RATE_C, ...
+    TAP, SHIFT, BR_STATUS, PF, QF, PT, QT, MU_SF, MU_ST, ...
+    ANGMIN, ANGMAX, MU_ANGMIN, MU_ANGMAX] = idx_brch;
+Vbase = mpc.bus(1, BASE_KV) * 1e3;      %% in Volts
+Sbase = mpc.baseMVA * 1e6;              %% in VA
+mpc.branch(:, [BR_R BR_X]) = mpc.branch(:, [BR_R BR_X]) / (Vbase^2 / Sbase);
+
+%% convert loads from kW to MW
+mpc.bus(:, [PD, QD]) = mpc.bus(:, [PD, QD]) / 1e3;

--- a/gym_anm/envs/ieee33_env/ieee33.py
+++ b/gym_anm/envs/ieee33_env/ieee33.py
@@ -1,0 +1,38 @@
+import numpy as np
+from ..anm_env import ANMEnv
+from .network import network
+
+
+class IEEE33Env(ANMEnv):
+    """ANM environment using the IEEE 33-bus distribution system."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self):
+        observation = "state"
+        K = 0
+        delta_t = 1.0
+        gamma = 0.99
+        lamb = 100
+        super().__init__(network, observation, K, delta_t, gamma, lamb)
+
+    def init_state(self):
+        n_dev = self.simulator.N_device
+        n_des = self.simulator.N_des
+        n_gen = self.simulator.N_non_slack_gen
+        state = np.zeros(2 * n_dev + n_des + n_gen + self.K)
+
+        # initialize loads to their nominal demand
+        idx = 0
+        for dev_id, dev in self.simulator.devices.items():
+            if dev.is_slack:
+                continue
+            p = dev.p_min
+            q = p * dev.qp_ratio
+            state[dev_id] = p
+            state[n_dev + dev_id] = q
+        return state
+
+    def next_vars(self, s_t):
+        # no stochastic variation
+        return np.zeros(self.simulator.N_load + self.simulator.N_non_slack_gen + self.K)

--- a/gym_anm/envs/ieee33_env/network.py
+++ b/gym_anm/envs/ieee33_env/network.py
@@ -1,0 +1,80 @@
+import numpy as np
+import re
+
+# Network data for the IEEE 33-bus distribution system
+# extracted from the MATPOWER case33bw file.
+
+
+def _load_case33bw(path):
+    text = open(path).read()
+
+    baseMVA = float(re.search(r"mpc.baseMVA\s*=\s*(\d+)", text).group(1))
+
+    def parse_block(name):
+        block = re.search(r"mpc.%s = \[(.*?)\];" % name, text, re.S).group(1)
+        rows = []
+        for line in block.strip().split("\n"):
+            line = line.strip()
+            if not line or line.startswith('%'):
+                continue
+            line = line.split('%')[0].strip()
+            if line.endswith(';'):
+                line = line[:-1]
+            nums = [float(n) for n in re.findall(r"-?\d+\.\d+|-?\d+", line)]
+            if nums:
+                rows.append(nums)
+        return rows
+
+    bus = parse_block("bus")
+    branch = parse_block("branch")
+    gen = parse_block("gen")
+    return baseMVA, bus, branch, gen
+
+
+# path of the original MATPOWER case file placed next to this script
+CASE_PATH = __file__.replace("network.py", "case33bw.m")
+baseMVA, bus_rows, branch_rows, _ = _load_case33bw(CASE_PATH)
+
+# Base values for per-unit conversion
+Vbase = bus_rows[0][9] * 1e3
+Sbase = baseMVA * 1e6
+
+# Bus specification array
+bus = []
+for row in bus_rows:
+    bus_id = int(row[0] - 1)
+    if row[1] == 3:
+        bus_type = 0  # slack
+    else:
+        bus_type = 1  # PQ bus
+    base_kv = row[9]
+    bus.append([bus_id, bus_type, base_kv, 1.1, 0.9])
+
+# Branch specification array
+branch = []
+for row in branch_rows:
+    f = int(row[0] - 1)
+    t = int(row[1] - 1)
+    r_pu = row[2] / (Vbase ** 2 / Sbase)
+    x_pu = row[3] / (Vbase ** 2 / Sbase)
+    branch.append([f, t, r_pu, x_pu, 0.0, 0.0, 1, 0])
+
+# Device specification array
+# Slack generator
+device = [
+    [0, 0, 0, None, 999, -999, 999, -999, None, None, None, None, None, None, None]
+]
+# Loads at all other buses
+dev_id = 1
+for row in bus_rows[1:]:
+    bus_id = int(row[0] - 1)
+    Pd = row[2] / 1000.0  # kW to MW
+    Qd = row[3] / 1000.0
+    qp = Qd / Pd if Pd else 0.0
+    device.append([dev_id, bus_id, -1, qp, 0, -Pd, None, None, None, None, None, None, None, None, None])
+    dev_id += 1
+
+network = {"baseMVA": baseMVA}
+network["bus"] = np.array(bus, dtype=float)
+network["device"] = np.array(device, dtype=object)
+network["branch"] = np.array(branch, dtype=float)

--- a/tests/test_ieee33_env.py
+++ b/tests/test_ieee33_env.py
@@ -1,0 +1,20 @@
+import unittest
+import numpy as np
+
+from gym_anm import IEEE33Env
+
+
+class TestIEEE33Env(unittest.TestCase):
+    def test_reset_and_step(self):
+        env = IEEE33Env()
+        obs, info = env.reset()
+        self.assertEqual(obs.shape[0], env.observation_space.shape[0])
+        a = env.action_space.sample()
+        obs, r, terminated, _, _ = env.step(a)
+        self.assertTrue(env.observation_space.contains(obs))
+        self.assertIsInstance(r, float)
+        self.assertIsInstance(terminated, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add IEEE33-v0 environment built from the MATPOWER case33bw
- register IEEE33-v0 in the package
- basic test checking the environment can reset and step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e728319f0832ea6b468fa4af5b12d