### PR TITLE
Add offline dataset mixing support

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,6 +92,7 @@ comes with its own rendering tool:
     :caption: Advanced
 
     topics/mpc
+    topics/offline_training
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/topics/offline_training.rst
+++ b/docs/source/topics/offline_training.rst
@@ -1,0 +1,26 @@
+.. _offline_training:
+
+Offline training utilities
+==========================
+
+The package provides basic utilities to collect datasets of state--action pairs
+which can later be used for behaviour cloning or other offline RL methods.
+
+Generating datasets
+-------------------
+
+Datasets can be created from a mix of agents with different levels of
+expertise.  The function :func:`generate_mixed_dataset` selects an agent from a
+given list at each step and records the resulting transition.  Agents can be
+drawn uniformly or according to user-specified sampling ``weights``.
+
+Several simple experts are provided.  In addition to conservative and
+aggressive variants, ``NoisyCapBankExpert`` simulates measurement errors while
+``DelayedCapBankExpert`` acts only every few steps. ``StaleCapBankExpert`` makes
+decisions using delayed observations.  These allow generating more realistic
+sub-optimal behaviour.
+
+.. literalinclude:: ../../../examples/offline_mixed.py
+   :language: python
+   :start-after: BEGIN OFFLINE MIXED EXAMPLE
+   :end-before: END OFFLINE MIXED EXAMPLE

--- a/examples/offline_mixed.py
+++ b/examples/offline_mixed.py
@@ -1,0 +1,24 @@
+"""Example of collecting a dataset from multiple agents."""
+
+import gymnasium as gym
+from gym_anm import (
+    generate_mixed_dataset,
+    SimpleCapBankExpert,
+    ConservativeCapBankExpert,
+    AggressiveCapBankExpert,
+    NoisyCapBankExpert,
+    DelayedCapBankExpert,
+)
+
+# BEGIN OFFLINE MIXED EXAMPLE
+env = gym.make("gym_anm:IEEE33-v0")
+expert1 = SimpleCapBankExpert(env)
+expert2 = ConservativeCapBankExpert(env)
+expert3 = AggressiveCapBankExpert(env)
+expert4 = NoisyCapBankExpert(env)
+expert5 = DelayedCapBankExpert(env)
+agents = [None, expert1, expert2, expert3, expert4, expert5]
+weights = [0.2, 0.2, 0.2, 0.2, 0.1, 0.1]
+
+states, actions = generate_mixed_dataset(env, agents, steps=10, weights=weights)
+# END OFFLINE MIXED EXAMPLE

--- a/gym_anm/__init__.py
+++ b/gym_anm/__init__.py
@@ -5,7 +5,18 @@ from gymnasium.envs.registration import register
 from .agents import MPCAgentPerfect, MPCAgentConstant
 from .envs import ANMEnv
 from .envs.ieee33_env import IEEE33Env
-from .offline import generate_dataset, behavior_cloning, evaluate_policy, SimpleCapBankExpert
+from .offline import (
+    generate_dataset,
+    generate_mixed_dataset,
+    behavior_cloning,
+    evaluate_policy,
+    SimpleCapBankExpert,
+    ConservativeCapBankExpert,
+    AggressiveCapBankExpert,
+    NoisyCapBankExpert,
+    DelayedCapBankExpert,
+    StaleCapBankExpert,
+)
 
 register(
     id="ANM6Easy-v0",

--- a/gym_anm/offline.py
+++ b/gym_anm/offline.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Optional, Callable
+from typing import Optional, Callable, Sequence
 from .envs.ieee33_env import IEEE33Env
 from .simulator.components import CapacitorBank
 
@@ -9,6 +9,67 @@ def generate_dataset(env, agent: Optional[Callable], steps: int):
     states, actions = [], []
     obs, _ = env.reset()
     for _ in range(steps):
+        if agent is None:
+            action = env.action_space.sample()
+        else:
+            action = agent.act(env)
+        next_obs, _, terminated, truncated, _ = env.step(action)
+        states.append(obs)
+        actions.append(action)
+        if terminated or truncated:
+            obs, _ = env.reset()
+        else:
+            obs = next_obs
+    return np.array(states), np.array(actions)
+
+
+def generate_mixed_dataset(
+    env, agents: Sequence[Optional[Callable]], steps: int, weights: Optional[Sequence[float]] = None
+):
+    """Collect a dataset from a mixture of agents.
+
+    Parameters
+    ----------
+    env : gym.Env
+        Environment in which to collect data.
+    agents : sequence of callables or ``None``
+        Agents used to generate the actions. If an element is ``None`` a random
+        action is sampled.
+    steps : int
+        Number of environment steps to record.
+    weights : sequence of float, optional
+        Sampling weights for the agents. ``weights[i]`` is proportional to the
+        probability of selecting ``agents[i]`` at each step. If ``None`` the
+        agents are sampled uniformly.
+
+    Returns
+    -------
+    states : :class:`numpy.ndarray`
+        Recorded observations.
+    actions : :class:`numpy.ndarray`
+        Actions taken at each state.
+    """
+
+    if weights is not None:
+        w = np.asarray(weights, dtype=float)
+        if len(w) != len(agents):
+            raise ValueError("weights must have the same length as agents")
+        if np.any(w < 0):
+            raise ValueError("weights must be non-negative")
+        probs = w / w.sum()
+
+        def pick_agent():
+            return agents[np.random.choice(len(agents), p=probs)]
+
+    else:
+
+        def pick_agent():
+            return np.random.choice(agents)
+
+    states, actions = [], []
+    obs, _ = env.reset()
+    for _ in range(steps):
+        agent = pick_agent()
         if agent is None:
             action = env.action_space.sample()
         else:
@@ -48,28 +109,120 @@ def evaluate_policy(env, policy, episodes: int = 1, max_steps: int = 10):
     return total_reward / episodes
 
 
-class SimpleCapBankExpert:
-    """A heuristic expert that tries to keep voltages close to 1.0 pu."""
+class CapBankExpert:
+    """General capacitor bank heuristic with configurable thresholds."""
 
-    def __init__(self, env: IEEE33Env):
+    def __init__(self, env: IEEE33Env, v_min: float = 0.99, v_max: float = 1.01):
         self.env = env
-        self.cap_ids = [
-            i
-            for i, d in env.unwrapped.simulator.devices.items()
-            if isinstance(d, CapacitorBank)
-        ]
+        self.v_min = v_min
+        self.v_max = v_max
+        self.cap_ids = [i for i, d in env.unwrapped.simulator.devices.items() if isinstance(d, CapacitorBank)]
 
     def act(self, env: IEEE33Env):
         action = np.zeros(env.action_space.shape[0])
         sim = env.unwrapped.simulator
         base = 0
-        # only capacitor actions present
         for idx, dev_id in enumerate(self.cap_ids):
             dev = sim.devices[dev_id]
             bus_v = np.abs(sim.buses[dev.bus_id].v)
-            if bus_v < 0.99:
+            if bus_v < self.v_min:
                 q = dev.q_max * sim.baseMVA
-            elif bus_v > 1.01:
+            elif bus_v > self.v_max:
+                q = dev.q_min * sim.baseMVA
+            else:
+                q = 0.0
+            action[base + idx] = q
+        return action
+
+
+class SimpleCapBankExpert(CapBankExpert):
+    """Heuristic expert with 0.99/1.01 voltage thresholds."""
+
+    def __init__(self, env: IEEE33Env):
+        super().__init__(env, v_min=0.99, v_max=1.01)
+
+
+class ConservativeCapBankExpert(CapBankExpert):
+    """Expert that acts only for larger voltage deviations."""
+
+    def __init__(self, env: IEEE33Env):
+        super().__init__(env, v_min=0.98, v_max=1.02)
+
+
+class AggressiveCapBankExpert(CapBankExpert):
+    """Expert that reacts to small voltage deviations."""
+
+    def __init__(self, env: IEEE33Env):
+        super().__init__(env, v_min=0.995, v_max=1.005)
+
+
+class NoisyCapBankExpert(CapBankExpert):
+    """Expert that senses voltages with Gaussian noise."""
+
+    def __init__(self, env: IEEE33Env, noise_std: float = 0.005):
+        super().__init__(env)
+        self.noise_std = noise_std
+
+    def act(self, env: IEEE33Env):
+        action = np.zeros(env.action_space.shape[0])
+        sim = env.unwrapped.simulator
+        base = 0
+        for idx, dev_id in enumerate(self.cap_ids):
+            dev = sim.devices[dev_id]
+            bus_v = np.abs(sim.buses[dev.bus_id].v)
+            bus_v += np.random.normal(0.0, self.noise_std)
+            if bus_v < self.v_min:
+                q = dev.q_max * sim.baseMVA
+            elif bus_v > self.v_max:
+                q = dev.q_min * sim.baseMVA
+            else:
+                q = 0.0
+            action[base + idx] = q
+        return action
+
+
+class DelayedCapBankExpert(CapBankExpert):
+    """Expert that only updates its action every ``delay`` steps."""
+
+    def __init__(self, env: IEEE33Env, delay: int = 2):
+        super().__init__(env)
+        self.delay = max(1, delay)
+        self._counter = 0
+
+    def act(self, env: IEEE33Env):
+        if self._counter % self.delay != 0:
+            self._counter += 1
+            return np.zeros(env.action_space.shape[0])
+        self._counter += 1
+        return super().act(env)
+
+
+class StaleCapBankExpert(CapBankExpert):
+    """Expert that uses observations from ``lag`` steps in the past."""
+
+    def __init__(self, env: IEEE33Env, lag: int = 1):
+        super().__init__(env)
+        self.lag = max(1, lag)
+        self._history: list[list[float]] = []
+
+    def act(self, env: IEEE33Env):
+        sim = env.unwrapped.simulator
+        current = [abs(sim.buses[sim.devices[dev_id].bus_id].v) for dev_id in self.cap_ids]
+        self._history.append(current)
+        if len(self._history) <= self.lag:
+            measure = current
+        else:
+            measure = self._history[0]
+            self._history.pop(0)
+
+        action = np.zeros(env.action_space.shape[0])
+        base = 0
+        for idx, dev_id in enumerate(self.cap_ids):
+            dev = sim.devices[dev_id]
+            bus_v = measure[idx]
+            if bus_v < self.v_min:
+                q = dev.q_max * sim.baseMVA
+            elif bus_v > self.v_max:
                 q = dev.q_min * sim.baseMVA
             else:
                 q = 0.0


### PR DESCRIPTION
## Summary
- enable collection of offline datasets from a mixture of agents
- add aggressive and conservative capacitor bank experts
- document offline training
- include example for mixed offline dataset generation
- cover new functionality with tests
- add noisy and delayed experts for more realistic sub-optimal behaviour
- **add weighted mixed dataset generation and stale observation expert**

## Testing
- `pytest -q`
- `make -C docs html`


------
https://chatgpt.com/codex/tasks/task_e_687e9c12ecdc832ea32613e472800676