### PR TITLE
Add human-like hysteresis expert

### DIFF
--- a/docs/source/topics/offline_training.rst
+++ b/docs/source/topics/offline_training.rst
@@ -17,8 +17,10 @@ resulting transition.
 Several simple experts are provided.  In addition to conservative and
 aggressive variants, ``NoisyCapBankExpert`` simulates measurement errors while
 ``DelayedCapBankExpert`` acts only every few steps.  ``LaggingCapBankExpert``
-makes decisions based on past voltage measurements.  These allow generating
-more realistic sub-optimal behaviour.
+makes decisions based on past voltage measurements.  ``HysteresisCapBankExpert``
+uses separate on/off voltage thresholds to replicate the hysteresis often present
+in human operator actions.  These allow generating more realistic sub-optimal
+behaviour.
 
 .. literalinclude:: ../../../examples/offline_mixed.py
    :language: python

--- a/examples/offline_mixed.py
+++ b/examples/offline_mixed.py
@@ -8,6 +8,7 @@ from gym_anm import (
     NoisyCapBankExpert,
     DelayedCapBankExpert,
     LaggingCapBankExpert,
+    HysteresisCapBankExpert,
 )
 
 # BEGIN OFFLINE MIXED EXAMPLE
@@ -18,8 +19,9 @@ expert3 = AggressiveCapBankExpert(env)
 expert4 = NoisyCapBankExpert(env)
 expert5 = DelayedCapBankExpert(env)
 expert6 = LaggingCapBankExpert(env)
-agents = [None, expert1, expert2, expert3, expert4, expert5, expert6]
+expert7 = HysteresisCapBankExpert(env)
+agents = [None, expert1, expert2, expert3, expert4, expert5, expert6, expert7]
 
-weights = [0.2, 0.2, 0.1, 0.1, 0.1, 0.2, 0.1]
+weights = [0.15, 0.2, 0.1, 0.1, 0.1, 0.15, 0.1, 0.1]
 states, actions = generate_mixed_dataset(env, agents, steps=10, weights=weights)
 # END OFFLINE MIXED EXAMPLE

--- a/gym_anm/__init__.py
+++ b/gym_anm/__init__.py
@@ -16,6 +16,7 @@ from .offline import (
     NoisyCapBankExpert,
     DelayedCapBankExpert,
     LaggingCapBankExpert,
+    HysteresisCapBankExpert,
 )
 
 register(

--- a/tests/test_offline_rl.py
+++ b/tests/test_offline_rl.py
@@ -12,6 +12,7 @@ from gym_anm import (
     NoisyCapBankExpert,
     DelayedCapBankExpert,
     LaggingCapBankExpert,
+    HysteresisCapBankExpert,
 )
 
 
@@ -24,7 +25,6 @@ def test_offline_rl_basic():
 
     rand_policy = behavior_cloning(rand_states, rand_actions, env.action_space)
     exp_policy = behavior_cloning(exp_states, exp_actions, env.action_space)
-
 
     rand_perf = evaluate_policy(env, rand_policy, episodes=1, max_steps=2)
     exp_perf = evaluate_policy(env, exp_policy, episodes=1, max_steps=2)
@@ -68,3 +68,10 @@ def test_mixed_dataset_weights():
     )
 
     np.testing.assert_allclose(actions_a, actions_b)
+
+
+def test_hysteresis_expert_dataset():
+    env = IEEE33Env()
+    expert = HysteresisCapBankExpert(env)
+    states, actions = generate_dataset(env, expert, 3)
+    assert states.shape[0] == actions.shape[0] == 3


### PR DESCRIPTION
## Summary
- add `HysteresisCapBankExpert` to model operator hysteresis when generating datasets
- document the new expert in offline training docs
- use hysteresis expert in example
- expose expert in package API
- test dataset collection with the new expert

## Testing
- `black gym_anm/offline.py gym_anm/__init__.py tests/test_offline_rl.py examples/offline_mixed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eab432dac832e950abc4932b3e3c6