### PR TITLE
Add OLTC support

### DIFF
--- a/gym_anm/__init__.py
+++ b/gym_anm/__init__.py
@@ -17,6 +17,8 @@ from .offline import (
     DelayedCapBankExpert,
     LaggingCapBankExpert,
     HysteresisCapBankExpert,
+    OLTCExpert,
+    RenewableGenExpert,
 )
 
 register(

--- a/gym_anm/envs/ieee33_env/network.py
+++ b/gym_anm/envs/ieee33_env/network.py
@@ -80,6 +80,10 @@ dev_id += 1
 device.append([dev_id, 25, 4, None, 0, 0, 1.0, -1.0, None, None, None, None, None, None, None])
 dev_id += 1
 
+# Add an OLTC on the slack branch between bus 0 and bus 1
+device.append([dev_id, 0, 5, 1, 1.1, 0.9, None, None, None, None, None, None, None, None, None])
+dev_id += 1
+
 network = {"baseMVA": baseMVA}
 network["bus"] = np.array(bus, dtype=float)
 network["device"] = np.array(device, dtype=object)

--- a/gym_anm/simulator/components/__init__.py
+++ b/gym_anm/simulator/components/__init__.py
@@ -8,4 +8,5 @@ from .devices import (
     Generator,
     Device,
     CapacitorBank,
+    OLTC,
 )

--- a/tests/simulator/test_devices.py
+++ b/tests/simulator/test_devices.py
@@ -22,7 +22,7 @@ class TestDevice(unittest.TestCase):
                 Device(spec, self.bus_ids, self.baseMVA)
 
     def test_bad_type(self):
-        for t in [None, -3, -2, 4, 5]:
+        for t in [None, -3, -2, 6]:
             spec = np.array([2, 3, t, None, None, None, None, None, None, None, None, None, None, None, None])
             with self.assertRaises(DeviceSpecError):
                 Device(spec, self.bus_ids, self.baseMVA)

--- a/tests/test_oltc.py
+++ b/tests/test_oltc.py
@@ -1,0 +1,25 @@
+import numpy as np
+from gym_anm.simulator import Simulator
+
+
+def test_oltc_control():
+    network = {
+        "baseMVA": 1,
+        "bus": np.array([[0, 0, 50, 1.0, 1.0], [1, 1, 50, 1.1, 0.9]]),
+        "branch": np.array([[0, 1, 0.01, 0.1, 0.0, 32, 1, 0]]),
+        "device": np.array(
+            [
+                [0, 0, 0, None, 200, -200, 200, -200, None, None, None, None, None, None, None],
+                [1, 0, 5, 1, 1.1, 0.9, None, None, None, None, None, None, None, None, None],
+            ],
+            dtype=object,
+        ),
+    }
+    sim = Simulator(network, 1.0, 100)
+    P_load = {}
+    P_pot = {}
+    P_set = {}
+    Q_set = {}
+    taps = {1: 1.05}
+    sim.transition(P_load, P_pot, P_set, Q_set, taps)
+    assert abs(sim.branches[(0, 1)].tap_magn - 1.05) < 1e-6


### PR DESCRIPTION
## Summary
- implement OLTC device class
- allow Simulator to control OLTCs and rebuild Ybus
- extend action space and environment parsing for OLTC
- update heuristics for new action dimension
- add OLTC unit test and modify existing tests
- include OLTC in IEEE33 network definition
- expand offline RL experts to handle transformer and renewable generator control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb971fea4832ebb0b601ef76c4c10